### PR TITLE
Fix npm test prefix not including libexec

### DIFF
--- a/Formula/lanraragi.rb
+++ b/Formula/lanraragi.rb
@@ -58,6 +58,6 @@ class Lanraragi < Formula
     ENV["PERL5LIB"] = libexec/"lib/perl5"
     ENV["LRR_LOG_DIRECTORY"] = testpath/"log"
 
-    system "npm", "--prefix", prefix, "test"
+    system "npm", "--prefix", libexec, "test"
   end
 end


### PR DESCRIPTION
Dug a bit into why the CI failed on the homebrew side and found this.